### PR TITLE
Add --no-push argument

### DIFF
--- a/bin/gerpush
+++ b/bin/gerpush
@@ -45,4 +45,6 @@ CHENGE_ID_MESSAGE="Change-Id: $CHENGE_ID"
 git reset --soft $BASE_HASH
 git commit -m "$(printf "$MESSAGE")" -m "$BODY" -m "$CHENGE_ID_MESSAGE"
 
-git push origin HEAD:refs/for/master
+if [ "$NO_PUSH" = false ]; then 
+  git push origin HEAD:refs/for/master
+fi

--- a/utils/help.sh
+++ b/utils/help.sh
@@ -14,5 +14,8 @@ help() {
       echo "-m <msg>, --message=<msg>"
       echo "Use the given <msg> as the commit message. If multiple -m options
            are given, their values are concatenated as separate paragraphs."
+      echo 
+      echo "--no-push"
+      echo "prevents pushing to the remote."
       echo
 }

--- a/utils/parse.sh
+++ b/utils/parse.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-echo $@
 source "${BASH_SOURCE%/*}/help.sh"
 
 MESSAGE=
+NO_PUSH=false
 
 
 while test $# -gt 0; do
@@ -21,6 +21,10 @@ while test $# -gt 0; do
         exit 1
       fi
       ;;
+    --no-push)
+      shift
+      NO_PUSH=true
+      ;;
     *)
       echo "gerpush: ${1} is not a gerpush command. See 'gerpush --help'."
       exit 1
@@ -30,3 +34,4 @@ done
 
 
 export MESSAGE
+export NO_PUSH


### PR DESCRIPTION
`--no-push` prevents pushing to the remote.

Closes #1 